### PR TITLE
Add frame_id to image msg

### DIFF
--- a/src/image_publisher.cpp
+++ b/src/image_publisher.cpp
@@ -28,6 +28,7 @@ ImagePublisher::ImagePublisher(ros::NodeHandle nh_p, CameraHWParameters params, 
   image_msg.data.resize(IMAGE_SIZE);
   image_msg.height = RES_Y;
   image_msg.width = RES_X;
+  image_msg.header.frame_id = "ovc_image_link";
   if (params.is_rgb)
     image_msg.encoding="bayer_grbg8";
   else


### PR DESCRIPTION
Adds a frame_id to the header of all published image messages. This is to help facilitate interactions with TF in downstream ROS nodes.